### PR TITLE
Add badge after completing final survey - story #129320845

### DIFF
--- a/app/services/mentee_final_survey_form.rb
+++ b/app/services/mentee_final_survey_form.rb
@@ -24,6 +24,7 @@ class MenteeFinalSurveyForm
   def save
     survey = FinalSurvey.find_or_initialize_by(project_id: @user.project.id)
     survey.update_attributes(attributes.merge({mentee_id: @user.id, edition_id: @user.id}))
+    @user.badges << Badge.final_survey
   end
 end
 


### PR DESCRIPTION
Right now, I've only created a DB record for the badge and added the seeds for the two survey badges. I opened the PR for early review and discussion.
Questions:
1. Wouldn't it be better to create all seed records at once, so we can use ID constants instead of name when assigning the badge?
2. Are we going to give the user a message that they received a badge, or just place them on their profile?