### PR TITLE
Rematching functionality

### DIFF
--- a/app/controllers/mentor_to_mentee_matchers_controller.rb
+++ b/app/controllers/mentor_to_mentee_matchers_controller.rb
@@ -24,26 +24,29 @@ class MentorToMenteeMatchersController < ApplicationController
   end
 
   def rematch
+    pairs_number = ApplicationMatch.all.count
+
     ActiveRecord::Base.transaction do
       MentorToMenteeMatcher.new.rematch
       create_projects
 
-      MenteeApplication.where(state: 5).each do |application|
+      MenteeApplication.waiting_for_rematch.each do |application|
         if application.user.project.present?
           application.update_attributes(state: :rematched)
         end
       end
 
-      MentorApplication.where(state: 5).each do |application|
+      MentorApplication.waiting_for_rematch.each do |application|
         if application.user.project.present?
           application.update_attributes(state: :rematched)
         end
       end
-
     end
 
+    pairs_number = ApplicationMatch.all.count - pairs_number
+
     respond_to do |format|
-      format.json { render json: {}, status: :ok }
+      format.json { render json: { number: pairs_number }, status: :ok }
     end
   end
 

--- a/app/controllers/mentor_to_mentee_matchers_controller.rb
+++ b/app/controllers/mentor_to_mentee_matchers_controller.rb
@@ -2,7 +2,9 @@ class MentorToMenteeMatchersController < ApplicationController
   def index
     locals={
       all_applications_evaluated: all_applications_evaluated?,
-      matched_paires: ApplicationMatch.all.order("created_at DESC")
+      matched_paires: ApplicationMatch.all.order("created_at DESC"),
+      mentors_waiting_for_re_match: MentorApplication.where(state: 5),
+      mentees_waiting_for_re_match: MenteeApplication.where(state: 5),
     }
 
     render 'index', locals: locals

--- a/app/controllers/mentor_to_mentee_matchers_controller.rb
+++ b/app/controllers/mentor_to_mentee_matchers_controller.rb
@@ -15,12 +15,7 @@ class MentorToMenteeMatchersController < ApplicationController
 
     ActiveRecord::Base.transaction do
       number = MentorToMenteeMatcher.new.run
-
-      ApplicationMatch.all.each do |application|
-        ProjectSetup.new(mentor_application: application.mentor_application,
-                         mentee_application: application.mentee_application)
-                    .create
-      end
+      create_projects
     end
 
     respond_to do |format|
@@ -28,9 +23,41 @@ class MentorToMenteeMatchersController < ApplicationController
     end
   end
 
+  def rematch
+    ActiveRecord::Base.transaction do
+      MentorToMenteeMatcher.new.rematch
+      create_projects
+
+      MenteeApplication.where(state: 5).each do |application|
+        if application.user.project.present?
+          application.update_attributes(state: :rematched)
+        end
+      end
+
+      MentorApplication.where(state: 5).each do |application|
+        if application.user.project.present?
+          application.update_attributes(state: :rematched)
+        end
+      end
+
+    end
+
+    respond_to do |format|
+      format.json { render json: {}, status: :ok }
+    end
+  end
+
   private
 
   def all_applications_evaluated?
     (MenteeApplication.left_for_evaluation + MentorApplication.left_for_evaluation) == 0
+  end
+
+  def create_projects
+    ApplicationMatch.all.each do |application|
+      ProjectSetup.new(mentor_application: application.mentor_application,
+                       mentee_application: application.mentee_application)
+        .create
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,6 +41,15 @@ class UsersController < ApplicationController
     redirect_to :back
   end
 
+  def report_resignation
+    authorized_user
+    user = User.find(params[:id])
+
+    UserResignation.new(user: user).proceed(reason: params[:reason])
+
+    redirect_to mentor_to_mentee_matchers_path
+  end
+
   private
 
   def user_params

--- a/app/models/mentee_application.rb
+++ b/app/models/mentee_application.rb
@@ -13,7 +13,8 @@ class MenteeApplication < ActiveRecord::Base
                 rejected: 3,
                 evaluated: 4,
                 waiting_for_rematch: 5,
-                rematched: 6 }
+                rematched: 6,
+                user_resigned: 7 }
 
   scope :not_rejected, -> { where.not(state: 3).where.not(state: 'rejected') }
   scope :not_evaluated, -> { not_rejected.eager_load(:evaluations).where('evaluations IS NULL') }

--- a/app/models/mentor_application.rb
+++ b/app/models/mentor_application.rb
@@ -11,7 +11,8 @@ class MentorApplication < ActiveRecord::Base
                 rejected: 3,
                 evaluated: 4,
                 waiting_for_rematch: 5,
-                rematched: 6 }
+                rematched: 6,
+                user_resigned: 7 }
 
   scope :not_rejected, -> { where.not(state: 3).where.not(state: 'rejected') }
   scope :not_evaluated, -> { not_rejected.eager_load(:evaluations).where('evaluations IS NULL') }

--- a/app/models/mentor_to_mentee_matcher.rb
+++ b/app/models/mentor_to_mentee_matcher.rb
@@ -67,13 +67,13 @@ class MentorToMenteeMatcher
 
   def all_mentors
     MentorApplication.evaluated.where("evaluations.score >= ?", 40)
-        .where.not(id: ApplicationMatch.pluck(:mentor_application_id))
-        .order("evaluations.score DESC")
-        .where.not(state: 7)
+      .where.not(id: ApplicationMatch.pluck(:mentor_application_id))
+      .order("evaluations.score DESC")
+      .where.not(state: MentorApplication.states[:user_resigned])
   end
 
   def mentors_waiting_for_rematch
-    all_mentors.where(state: 5)
+    all_mentors.waiting_for_rematch
   end
 
   def all_mentees(language, country)
@@ -82,7 +82,7 @@ class MentorToMenteeMatcher
       .where(programming_languages: {slug: language[:slug].downcase})
       .order("evaluations.score DESC")
       .where.not(id: ApplicationMatch.pluck(:mentee_application_id))
-      .where.not(state: 7)
+      .where.not(state: MenteeApplication.states[:user_resigned])
   end
 
   def all_ordered_mentees(language, country)
@@ -91,7 +91,7 @@ class MentorToMenteeMatcher
   end
 
   def mentees_waiting_for_rematch(language, country)
-    mentees = all_mentees(language, country).where(state: 5)
+    mentees = all_mentees(language, country).waiting_for_rematch
     mentees.where.not(country: country) + mentees.where(country: country) 
   end
 

--- a/app/models/mentor_to_mentee_matcher.rb
+++ b/app/models/mentor_to_mentee_matcher.rb
@@ -1,6 +1,9 @@
 class MentorToMenteeMatcher
+  attr_reader :mentor_evaluation_maximum_score
 
   def run
+    @mentor_evaluation_maximum_score = 40
+
     match_algorithm(with_time_zone: true)
     match_algorithm(with_time_zone: false)
 
@@ -8,6 +11,8 @@ class MentorToMenteeMatcher
   end
 
   def rematch
+    @mentor_evaluation_maximum_score = 30
+
     rematch_for_waiting_mentors_and_mentees(with_time_zone: true)
     rematch_for_waiting_mentors_and_mentees(with_time_zone: false)
 
@@ -66,7 +71,7 @@ class MentorToMenteeMatcher
   end
 
   def all_mentors
-    MentorApplication.evaluated.where("evaluations.score >= ?", 40)
+    MentorApplication.evaluated.where("evaluations.score >= ?", mentor_evaluation_maximum_score)
       .where.not(id: ApplicationMatch.pluck(:mentor_application_id))
       .order("evaluations.score DESC")
       .where.not(state: MentorApplication.states[:user_resigned])
@@ -87,7 +92,7 @@ class MentorToMenteeMatcher
 
   def all_ordered_mentees(language, country)
     mentees = all_mentees(language, country)
-    mentees.where.not(country: country) + mentees.where(country: country) 
+    mentees.where.not(country: country) + mentees.where(country: country)
   end
 
   def mentees_waiting_for_rematch(language, country)

--- a/app/models/mentor_to_mentee_matcher.rb
+++ b/app/models/mentor_to_mentee_matcher.rb
@@ -1,20 +1,50 @@
 class MentorToMenteeMatcher
 
   def run
-    matcher_algorithm(with_time_zone: true)
-    matcher_algorithm(with_time_zone: false)
+    match_algorithm(with_time_zone: true)
+    match_algorithm(with_time_zone: false)
 
     p ApplicationMatch.all.size
   end
 
+  def rematch
+    rematch_for_waiting_mentors_and_mentees(with_time_zone: true)
+    rematch_for_waiting_mentors_and_mentees(with_time_zone: false)
+
+    rematch_for_waiting_mentors(with_time_zone: true)
+    rematch_for_waiting_mentors(with_time_zone: false)
+
+    rematch_for_waiting_mentees(with_time_zone: true)
+    rematch_for_waiting_mentees(with_time_zone: false)
+
+    match(with_time_zone: true)
+    match(with_time_zone: false)
+  end
+
   private
 
-  def matcher_algorithm(with_time_zone: true)
-    mentors.each do |mentor|
-      languages = count_languages
+  def match(with_time_zone: true)
+    run_algorithm(:all_mentors, :all_ordered_mentees, with_time_zone)
+  end
+
+  def rematch_for_waiting_mentors_and_mentees(with_time_zone: true)
+    run_algorithm(:mentors_waiting_for_rematch, :mentees_waiting_for_rematch, with_time_zone)
+  end
+
+  def rematch_for_waiting_mentors(with_time_zone: true)
+    run_algorithm(:mentors_waiting_for_rematch, :all_ordered_mentees, with_time_zone)
+  end
+
+  def rematch_for_waiting_mentees(with_time_zone: true)
+    run_algorithm(:all_mentors, :mentees_waiting_for_rematch, with_time_zone)
+  end
+
+  def run_algorithm(mentors, mentees, with_time_zone)
+    send(mentors).each do |mentor|
+      languages = count_languages(mentors)
       languages.each do |language|
         if mentor.programming_languages.pluck(:slug).include?(language[:slug])
-          break unless mentees(language, mentor.country).each do |mentee|
+          break unless send(mentees,language, mentor.country).each do |mentee|
             if !with_time_zone || (timezone_difference(mentor.time_zone, mentee.time_zone) <= 2)
               ApplicationMatch.create!(mentor_application_id: mentor.id, mentee_application_id: mentee.id)
               break
@@ -25,9 +55,9 @@ class MentorToMenteeMatcher
     end
   end
 
-  def count_languages
+  def count_languages(mentors)
     ProgrammingLanguage.joins(:mentor_applications)
-           .where(mentor_applications: {id: mentors.pluck(:id)})
+           .where(mentor_applications: {id: send(mentors).pluck(:id)})
            .pluck(:slug)
            .flatten
            .group_by {|x| x }
@@ -35,19 +65,33 @@ class MentorToMenteeMatcher
            .sort_by { |x| x[:number] }
   end
 
-  def mentors
+  def all_mentors
     MentorApplication.evaluated.where("evaluations.score >= ?", 40)
         .where.not(id: ApplicationMatch.pluck(:mentor_application_id))
         .order("evaluations.score DESC")
+        .where.not(state: 7)
   end
 
-  def mentees(language, country)
-    mentees = MenteeApplication.evaluated.where("evaluations.score >= ?", 10)
-                               .joins(:programming_language)
-                               .where(programming_languages: {slug: language[:slug].downcase})
-                               .order("evaluations.score DESC")
-                               .where.not(id: ApplicationMatch.pluck(:mentee_application_id))
+  def mentors_waiting_for_rematch
+    all_mentors.where(state: 5)
+  end
 
+  def all_mentees(language, country)
+    MenteeApplication.evaluated.where("evaluations.score >= ?", 10)
+      .joins(:programming_language)
+      .where(programming_languages: {slug: language[:slug].downcase})
+      .order("evaluations.score DESC")
+      .where.not(id: ApplicationMatch.pluck(:mentee_application_id))
+      .where.not(state: 7)
+  end
+
+  def all_ordered_mentees(language, country)
+    mentees = all_mentees(language, country)
+    mentees.where.not(country: country) + mentees.where(country: country) 
+  end
+
+  def mentees_waiting_for_rematch(language, country)
+    mentees = all_mentees(language, country).where(state: 5)
     mentees.where.not(country: country) + mentees.where(country: country) 
   end
 

--- a/app/models/mentor_to_mentee_matcher.rb
+++ b/app/models/mentor_to_mentee_matcher.rb
@@ -22,6 +22,8 @@ class MentorToMenteeMatcher
     rematch_for_waiting_mentees(with_time_zone: true)
     rematch_for_waiting_mentees(with_time_zone: false)
 
+    @mentor_evaluation_maximum_score = 40
+
     match(with_time_zone: true)
     match(with_time_zone: false)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,6 +64,10 @@ class User < ActiveRecord::Base
     role == "mentee" ? mentee_final_survey : mentor_final_survey
   end
 
+  def application
+    role == "mentee" ? mentee_application : mentor_application
+  end
+
   def self.mentees_missing_on_website
     mentees_missing = User.mentee.where("last_activity_at is null or last_activity_at <= (?)", 15.days.ago)
     mentees_missing = mentees_missing.where.not("is_missing = (?) OR (send_warning_email_after is not null AND send_warning_email_after > (?))", true, Date.today)

--- a/app/models/user_resignation.rb
+++ b/app/models/user_resignation.rb
@@ -1,0 +1,45 @@
+class UserResignation
+  attr_reader :user, :partner, :project, :reason
+
+  def initialize(user:)
+    @user = user
+    @partner = user.partner
+    @project = user.project
+  end
+
+  def proceed(reason:)
+    @reason = reason
+
+    ActiveRecord::Base.transaction do
+      application_match.delete
+      project.delete
+
+      handle_user_state
+      handle_partner_state
+
+    end
+  end
+
+  private
+
+  def application_match
+    ids = [user.application.id, partner.application.id]
+    ApplicationMatch.where(mentor_application_id: ids, mentee_application_id: ids).first
+  end
+
+  def handle_user_state
+    application = user.application
+    application.state = :user_resigned
+    application.resignation_reason = reason
+    application.save
+
+    user.delete
+  end
+
+  def handle_partner_state
+    application = partner.application
+    application.state = :waiting_for_rematch
+    application.rematch_reason = reason
+    application.save
+  end
+end

--- a/app/views/mentor_to_mentee_matchers/index.html.slim
+++ b/app/views/mentor_to_mentee_matchers/index.html.slim
@@ -1,19 +1,62 @@
 .page-header
   h1.text-center.green-text Mentors and Mentees pairs
 
-- if all_applications_evaluated
+- if all_applications_evaluated && matched_paires.empty?
   .row
     .col-xs-4.col-xs-offset-4.text-center
       = form_for(:match, remote:true, url: { action: 'match'}, html: {id: 'match-form'}) do |f|
         = f.submit 'Match!', class: 'btn btn-pink', data: { disable_with: "Matching in progress..." }
         .row
           .col-xs-12.text-center.info
-- else
+- elsif !all_applications_evaluated
   h3 If you don't see matching button, that means there are still applications to evaluate. Check those pages:
   h4.text-center
     = link_to "Dashboard", dashboard_organisers_url
   h4.text-center
     = link_to "Skipped Applications", skipped_applications_url
+
+- if mentors_waiting_for_re_match.present? || mentees_waiting_for_re_match.present?
+  br
+  .row
+    .col-xs-12.text-center
+      h2
+        div
+          |Mentor - Mentee
+      h4
+        div
+          | #{mentors_waiting_for_re_match.count + mentees_waiting_for_re_match.count} 
+          | waiting for re-match
+
+  - mentors_waiting_for_re_match.each do |mentor_application|
+    .row
+      .col-xs-8.col-xs-offset-2
+        hr
+      p.col-xs-6.text-right
+        strong
+          = mentor_application.first_name
+          |&nbsp;
+          = mentor_application.last_name
+        br
+        = mentor_application.programming_languages.pluck(:name).join(', ')
+      p.col-xs-6.text-left
+        span ----
+
+  - mentees_waiting_for_re_match.each do |mentee_application|
+    .row
+      .col-xs-8.col-xs-offset-2
+        hr
+      p.col-xs-6.text-right
+        span ----
+      p.col-xs-6.text-left
+        strong
+          = mentee_application.first_name
+          |&nbsp;
+          = mentee_application.last_name
+        br
+        = mentee_application.programming_language.name
+
+
+
 br
 .row
   .col-xs-12.text-center

--- a/app/views/mentor_to_mentee_matchers/index.html.slim
+++ b/app/views/mentor_to_mentee_matchers/index.html.slim
@@ -26,6 +26,10 @@
         div
           | #{mentors_waiting_for_re_match.count + mentees_waiting_for_re_match.count} 
           | waiting for re-match
+      = form_for(:rematch, remote:true, url: { action: 'rematch'}, html: {id: 'match-form'}) do |f|
+        = f.submit 'Re-match!', class: 'btn btn-pink', data: { disable_with: "Re-matching in progress..." }
+        .row
+          .col-xs-12.text-center.info
 
   - mentors_waiting_for_re_match.each do |mentor_application|
     .row

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -3,15 +3,15 @@
     = image_tag display_avatar(@user), alt: "Mentee's avatar", class: "profile-icon"
   .col-md-8.col-sm-9.col-xs-7
       h3.green-text
-       = @user.full_name
-       - if @user == current_user
-         .pull-right
-           = link_to @edit_url do
-             .fa.fa-pencil
-       - if current_user.role == "organizer" && @user.is_missing
-         .pull-right.red-text
-           | Abandoned since
-           = @user.missing_since.strftime("%B %d, %Y")
+        = @user.full_name
+        - if @user == current_user
+          .pull-right
+            = link_to @edit_url do
+              .fa.fa-pencil
+        - if current_user.role == "organizer" && @user.is_missing
+          .pull-right.red-text
+            | Abandoned since
+            = @user.missing_since.strftime("%B %d, %Y")
       p
         = "From: #{Carmen::Country.coded(@user.country)}"
       p
@@ -53,3 +53,27 @@
           = f.label "User unavailable until:"
           = f.text_field :warning_email_date, type: :date, class: "date-picker form-control", value: @user.send_warning_email_after
         = f.submit "Save new date", class: "btn btn-pink"
+
+- if current_user.role == "organizer"
+  .row
+    .co-md-8.col-md-offset-2.col-sm-10.col-sm-offset-1.col-xs-12
+      br
+      strong User Resigned: 
+      a.text-center href="javascript:$('#report-user-resign-modal').modal();" report
+
+#report-user-resign-modal.modal.fade role="dialog" tabindex="-1" 
+  .modal-dialog role="document"
+    .modal-content
+      = form_tag report_resignation_user_path(@user), method: :put
+      .modal-header
+        button.close aria-label="Close" data-dismiss="modal" type="button" 
+          span aria-hidden="true"  &times;
+        h4.modal-title Notify about user resignation
+      .modal-body
+        div By continuing, you will remove the user and project. You will also set this user partner on the waiting list for re-match
+        br
+        div Reason of resignation:
+        = text_area_tag :reason, nil, rows: 5, style: "min-width: 100%"
+      .modal-footer
+        button.btn.btn-default data-dismiss="modal" type="button"  Close
+        = submit_tag "Save changes", class: "button btn btn-primary" 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -68,7 +68,7 @@
       .modal-header
         button.close aria-label="Close" data-dismiss="modal" type="button" 
           span aria-hidden="true"  &times;
-        h4.modal-title Notify about user resignation
+        h4.modal-title Report user resignation
       .modal-body
         div By continuing, you will remove the user and project. You will also set this user partner on the waiting list for re-match
         br

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -73,7 +73,7 @@
         div By continuing, you will remove the user and project. You will also set this user partner on the waiting list for re-match
         br
         div Reason of resignation:
-        = text_area_tag :reason, nil, rows: 5, style: "min-width: 100%"
+        = text_area_tag :reason, nil, rows: 5, style: "min-width: 100%", required: true
       .modal-footer
         button.btn.btn-default data-dismiss="modal" type="button"  Close
         = submit_tag "Save changes", class: "button btn btn-primary" 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,12 @@ Webplatform::Application.routes.draw do
     get "learning_materials/#{language}" => "learning_materials##{language}", as: "#{language}_learning_materials"
   end
 
+  resources :users, only: [] do
+    member do
+      put :report_resignation
+    end
+  end
+
   resources :mentee_profiles, only: [:show, :edit, :update] do
     collection do
       get :dashboard
@@ -76,11 +82,6 @@ Webplatform::Application.routes.draw do
   resources :mentor_to_mentee_matchers do
     collection do
       post :match
-    end
-    member do
-      put :accept_pair
-      put :reject_mentee
-      put :reject_mentor
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Webplatform::Application.routes.draw do
   resources :mentor_to_mentee_matchers do
     collection do
       post :match
+      post :rematch
     end
   end
 

--- a/db/migrate/20170924003656_add_resignation_and_rematch_reasons_to_applications.rb
+++ b/db/migrate/20170924003656_add_resignation_and_rematch_reasons_to_applications.rb
@@ -1,0 +1,8 @@
+class AddResignationAndRematchReasonsToApplications < ActiveRecord::Migration
+  def change
+    add_column :mentor_applications, :resignation_reason, :text
+    add_column :mentor_applications, :rematch_reason, :text
+    add_column :mentee_applications, :resignation_reason, :text
+    add_column :mentee_applications, :rematch_reason, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170923203720) do
+ActiveRecord::Schema.define(version: 20170924003656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,8 @@ ActiveRecord::Schema.define(version: 20170923203720) do
     t.integer  "programming_language_id"
     t.integer  "edition_id"
     t.datetime "confirmation_email_sent_at"
+    t.text     "resignation_reason"
+    t.text     "rematch_reason"
   end
 
   create_table "mentee_midterm_evaluations", force: :cascade do |t|
@@ -170,6 +172,8 @@ ActiveRecord::Schema.define(version: 20170923203720) do
     t.string   "operating_system"
     t.integer  "edition_id"
     t.datetime "confirmation_email_sent_at"
+    t.text     "resignation_reason"
+    t.text     "rematch_reason"
   end
 
   create_table "mentor_applications_programming_languages", id: false, force: :cascade do |t|


### PR DESCRIPTION
On _/mentee_profiles/:id_ and _/mentee_profiles/:id_ pages You'll be able to find a 'report user resign' link:

![image](https://user-images.githubusercontent.com/5939407/30778794-1690d146-a0df-11e7-81f9-b1da04eb4750.png)

After using it, the popup will appear:

![image](https://user-images.githubusercontent.com/5939407/30778808-501f52c0-a0df-11e7-8e59-132360da409a.png)

Next, on the page with list of pairs, I've added a section for re-matching with list and proper button:

![image](https://user-images.githubusercontent.com/5939407/30778826-a190c6b6-a0df-11e7-86bd-b4764bee4374.png)

The algorithm I used is based on matching algorithm, but it'll give a 'waiting' mentors and metees, a priority in matching process
