### PR TITLE
Email templates for re-matching steps

### DIFF
--- a/app/assets/stylesheets/application/email_templates.scss
+++ b/app/assets/stylesheets/application/email_templates.scss
@@ -27,6 +27,9 @@ body.email_templates-controller {
 
     .template-header {
       border-bottom: 1px solid $border-color;
+      .for-note{
+        line-height: 20px;
+      }
       padding: 10px 20px;
       &, h4 {
         line-height: 34px;

--- a/app/controllers/mentor_to_mentee_matchers_controller.rb
+++ b/app/controllers/mentor_to_mentee_matchers_controller.rb
@@ -33,12 +33,14 @@ class MentorToMenteeMatchersController < ApplicationController
       MenteeApplication.waiting_for_rematch.each do |application|
         if application.user.project.present?
           application.update_attributes(state: :rematched)
+          update_partner_application_state(application)
         end
       end
 
       MentorApplication.waiting_for_rematch.each do |application|
         if application.user.project.present?
           application.update_attributes(state: :rematched)
+          update_partner_application_state(application)
         end
       end
     end
@@ -62,5 +64,15 @@ class MentorToMenteeMatchersController < ApplicationController
                        mentee_application: application.mentee_application)
         .create
     end
+  end
+
+  def update_partner_application_state(application)
+   partner_application = application.user.partner.application
+
+   if application.rematched? && partner_application.waiting_for_rematch?
+      partner_application.update_attributes(state: :rematched)
+   elsif application.rematched? && partner_application.evaluated?
+      partner_application.update_attributes(state: :rematched_from_waiting_list)
+   end
   end
 end

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -22,7 +22,15 @@ class EmailTemplate < ActiveRecord::Base
     final_passing_mentors: 21,
     final_failed_mentors: 22,
     final_passing_mentees: 23,
-    final_failed_mentees: 24
+    final_failed_mentees: 24,
+    mentees_who_have_resigned: 25,
+    mentors_who_have_resigned: 26,
+    mentees_whose_partners_have_resigned: 27,
+    mentors_whose_partners_have_resigned: 28,
+    mentees_who_got_partners_after_rematching: 29,
+    mentors_who_got_partners_after_rematching: 30,
+    mentees_from_waiting_list_who_got_partners_after_rematching: 31,
+    mentors_from_waiting_list_who_got_partners_after_rematching: 32
   }
 
   validates :subject, :body, :recipients, presence: true
@@ -70,6 +78,22 @@ class EmailTemplate < ActiveRecord::Base
       Project.with_passing_mentees.map{|p| p.mentee}
     when :final_failed_mentees
       Project.with_failed_mentees.map{|p| p.mentee}
+    when :mentees_who_have_resigned
+      MenteeApplication.user_resigned
+    when :mentors_who_have_resigned
+      MentorApplication.user_resigned
+    when :mentees_whose_partners_have_resigned
+      MenteeApplication.waiting_for_rematch
+    when :mentors_whose_partners_have_resigned
+      MentorApplication.waiting_for_rematch
+    when :mentees_who_got_partners_after_rematching
+      MenteeApplication.rematched
+    when :mentors_who_got_partners_after_rematching
+      MentorApplication.rematched
+    when :mentees_from_waiting_list_who_got_partners_after_rematching
+      MenteeApplication.rematched_from_waiting_list
+    when :mentors_from_waiting_list_who_got_partners_after_rematching
+      MentorApplication.rematched_from_waiting_list
     else
       User.none
     end

--- a/app/models/mentee_application.rb
+++ b/app/models/mentee_application.rb
@@ -14,7 +14,8 @@ class MenteeApplication < ActiveRecord::Base
                 evaluated: 4,
                 waiting_for_rematch: 5,
                 rematched: 6,
-                user_resigned: 7 }
+                user_resigned: 7,
+                rematched_from_waiting_list: 8}
 
   scope :not_rejected, -> { where.not(state: 3).where.not(state: 'rejected') }
   scope :not_evaluated, -> { not_rejected.eager_load(:evaluations).where('evaluations IS NULL') }

--- a/app/models/mentor_application.rb
+++ b/app/models/mentor_application.rb
@@ -12,7 +12,8 @@ class MentorApplication < ActiveRecord::Base
                 evaluated: 4,
                 waiting_for_rematch: 5,
                 rematched: 6,
-                user_resigned: 7 }
+                user_resigned: 7,
+                rematched_from_waiting_list: 8}
 
   scope :not_rejected, -> { where.not(state: 3).where.not(state: 'rejected') }
   scope :not_evaluated, -> { not_rejected.eager_load(:evaluations).where('evaluations IS NULL') }

--- a/app/views/email_templates/_email_template.html.slim
+++ b/app/views/email_templates/_email_template.html.slim
@@ -3,7 +3,7 @@
     .row
       .col-xs-6
         h4= email_template.subject
-      .col-sm-4.col-xs-6
+      .col-sm-4.col-xs-6.for-note
         = "For: #{email_template.recipients.humanize}"
       .col-sm-2.col-xs-12
         - if Rails.env.development?

--- a/lib/tasks/rematching_results.rake
+++ b/lib/tasks/rematching_results.rake
@@ -1,0 +1,34 @@
+namespace :rematching_results do
+  desc "mentees and mentors who have resigned"
+  task resigned_users: :environment do
+    email_templates = EmailTemplate.where(recipients: [25, 26])
+
+    email_templates.each do |template|
+      template.users.each do |user|
+        EmailTemplateMailer.custom(template, user).deliver_now
+      end
+    end
+  end
+
+  desc "mentees and mentors whos partners resigned"
+  task resigned_users_partners: :environment do
+    email_templates = EmailTemplate.where(recipients: [27, 28])
+
+    email_templates.each do |template|
+      template.users.each do |user|
+        EmailTemplateMailer.custom(template, user).deliver_now
+      end
+    end
+  end
+
+  desc "mentees and mentors who have been rematched"
+  task rematched_users: :environment do
+    email_templates = EmailTemplate.where(recipients: [29, 30, 31, 32])
+
+    email_templates.each do |template|
+      template.users.each do |user|
+        EmailTemplateMailer.custom(template, user).deliver_now
+      end
+    end
+  end
+end


### PR DESCRIPTION
in this pull request you'll find some new email template receivers type based on users re-matching process :)

I've also found it necessary to add additional state of application - :rematched_from_waiting_list that is set for the applications from waiting list, that were paired with :waiting_for_rematch users. As we talked before, it would be good to separated applications which were matched before from those that were not.