### PR TITLE
Improve project setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,11 @@ Then, you'll need to install gem dependencies:
 
     bundle install
 
+If you have any problem with `data-confirm-modal` try to manually install the gem:
+
+		gem install data-confirm-modal
+
+
 and setup database:
 
 * copy config/database_template.yml to config/database.yml and fill it in using your postgreSQL's credentials

--- a/db/migrate/20160510060724_add_mentor_evaluation_to_project.rb
+++ b/db/migrate/20160510060724_add_mentor_evaluation_to_project.rb
@@ -1,0 +1,5 @@
+class AddMentorEvaluationToProject < ActiveRecord::Migration
+  def up
+    add_column :projects, :mentor_evaluation, :integer
+  end
+end


### PR DESCRIPTION
Hi, I was just trying config this project at my machine to help with some front-end and some ideas, but to config I need to manually install the gem install data-confirm-modal, so I add this tip in CONTRIBUTING.md. 
And I also had to include a file called 20160510060724_add_mentor_evaluation_to_project.rb to add mentor_evaluation to project before the file AddEvaluationAttributesToProject since this one only change the attribute, even if the mentor_evaluation does not exist yet (for example on rake db:migrate). Hope this help you.